### PR TITLE
Port memory-based loader and CMAKE support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(NLTemplate)
+add_executable(${PROJECT_NAME} "NLTemplate/NLTemplate.cpp" "NLTemplate/test.cpp")

--- a/NLTemplate/NLTemplate.cpp
+++ b/NLTemplate/NLTemplate.cpp
@@ -347,6 +347,22 @@ Loader::Result LoaderFile::load( const string & name ) {
 }
 
 
+void LoaderMemory::add( const std::string & name, const std::string & body ) {
+    files.push_back( { name, body } );
+}
+
+
+Loader::Result LoaderMemory::load( const std::string & name ) {
+    for ( auto & pair : files ) {
+        if ( pair.first == name ) {
+            return { true, pair.second, "" };
+        }
+    }
+
+    return { false, nullptr, name + " not found." };
+}
+
+
 Template::Template( Loader & loader ) : Block( "main" ), loader( loader ) {
 }
 

--- a/NLTemplate/NLTemplate.h
+++ b/NLTemplate/NLTemplate.h
@@ -139,14 +139,25 @@ public:
 };
 
 
+class LoaderMemory : public Loader {
+private:
+    std::vector<std::pair<std::string, std::string> > files;
+public:
+    void add( const std::string & name, const std::string & body );
+    Result load( const std::string & name );
+};
+
+
 
 class Template : public Block {
 public:
+    using Block::render;
+
     Template( Loader & loader );
     void clear();
     void load( const std::string & name );
-    void render( std::ostream & output ) const;
-    
+    virtual void render( std::ostream & output ) const;
+
 private:
     Loader & loader;
 

--- a/NLTemplate/test.cpp
+++ b/NLTemplate/test.cpp
@@ -7,7 +7,7 @@ using namespace NL::Template;
 
 
 
-int main(int, char *[] ) {
+static void testFile() {
     const char *titles[ 3 ] = { "Chico", "Harpo", "Groucho" };
     const char *details[ 3 ] = { "Red", "Green", "Blue" };
 
@@ -36,6 +36,28 @@ int main(int, char *[] ) {
     }
     
     t.render( cout ); // Render the template with the variables we've set above
+}
+
+
+static void testMemory() {
+    NL::Template::LoaderMemory loader;
     
+    NL::Template::Template t( loader );
+    
+    loader.add( "base", "<html><head>{{ title }}</head>\n<body><p>{% include text %}</p></body></html>\n" );
+    loader.add( "text", "Hi there, {{ name }}. How are you??" );
+    
+    t.load( "base" );
+    t.set( "title", "Testing memory loader" );
+    t.set( "name", "Stranger" );
+    
+    t.render( std::cout );
+}
+
+
+int main(int, char *[] ) {
+    testFile();
+    testMemory();
+   
     return 0;
 }

--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
-##NLTemplate - simple HTML template library for C++##
+# NLTemplate - simple HTML template library for C++
 
-Use tags like **{{ variable }}** or **{% include header.html %}** or
-**{% block items %}{{ item }}{% endblock %}** in your template files.
+Use tags like `{{ variable }}` or `{% include header.html %} or
+`{% block items %}{{ item }}{% endblock %}` in your template files.
 Load the templates with NLTemplate, fill in the variables and setup the
 repeating blocks with C++ code and render the result to stdout or
 into a string.
 
-###Features###
+## Features
 
 - Variable replacement
 - Repeatable or optional blocks
 - File includes
 - No external dependencies
 
-###Requirements###
+## Requirements
 
 - C++11 (please use the C++98 branch if you need support for legacy compilers)
 
-###Installation###
+## Installation
 
 To start using NLTemplate, add NLTemplate.cpp to your project and make sure NLTemplate.h is in your header search path.
 
-###Demo###
+## Demo
 
 If you use Xcode, just open and run the demo project. On the command line, you could run the demo like this:
 
@@ -32,7 +32,7 @@ gcc -Wall -pedantic -o demo -lstdc++ *.cpp
 ./demo
 ```
 
-###Example###
+## Example
 
 ``` c++
 #include <iostream>
@@ -78,7 +78,7 @@ int main(int, char *[] ) {
 }
 ```
 
-###Example - test.txt###
+## Example - test.txt
 
 ``` html
 {% include header.txt %}
@@ -91,23 +91,23 @@ int main(int, char *[] ) {
 </p>{% endblock %}
 ```
 
-###Example - header.txt###
+## Example - header.txt
 
 ``` html
 <html><body>
 <h1>{{ text }}</h1>
 ```
 
-###Note about HTML###
+## Note about HTML
 
 Despite the headline, there is nothing HTML-specific in NLTemplate.
 You can use XML, JSON or plain text as well for your templates.
 
 
-###Personal note###
+## Personal note
 
 If you use NLTemplate in a project, I'd love to hear about it. Please do let me know at tom@catnapgames.com. Thanks!
 
-### See also ###
+## See also
 
 Goes well with [NLDatabase](https://github.com/catnapgames/NLDatabase) - a lightweight SQLite wrapper for C++.


### PR DESCRIPTION
This PR does the following:

* port the memory-based loader from the version in the zip on the website: https://www.catnapgames.com/2013/04/09/nltemplate-html-template-library-for-c/
* add CMAKE support
* fix the markdown of the README