### PR TITLE
Fix trivial gcc (6.3.1) warnings

### DIFF
--- a/NLTemplate/NLTemplate.cpp
+++ b/NLTemplate/NLTemplate.cpp
@@ -343,7 +343,7 @@ Loader::Result LoaderFile::load( const string & name ) {
     std::string content( (std::istreambuf_iterator<char>( input ) ),
                          (std::istreambuf_iterator<char>() ) );
 
-    return { true, content };
+    return { true, content, "" };
 }
 
 
@@ -359,7 +359,7 @@ Loader::Result LoaderMemory::load( const std::string & name ) {
         }
     }
 
-    return { false, nullptr, name + " not found." };
+    return { false, "", name + " not found." };
 }
 
 

--- a/NLTemplate/NLTemplate.h
+++ b/NLTemplate/NLTemplate.h
@@ -77,7 +77,7 @@ private:
 };
 
     
-}; // namespace Private
+} // namespace Private
 
     
     


### PR DESCRIPTION
Had a few errors:

```
    NLTemplate.cpp:346:28: error: missing initializer for member 'NL::Template::Loader::Result::error' [-Werror=missing-field-initializers]
    NLTemplate.cpp:362 initializer argument type
    
    NLTemplate.h:80:2: error: extra ';' [-Werror=pedantic]
    
    gcc 6.3.1
